### PR TITLE
DC SystemController does not show Images panel

### DIFF
--- a/openstack_dashboard/dashboards/admin/images/panel.py
+++ b/openstack_dashboard/dashboards/admin/images/panel.py
@@ -28,14 +28,3 @@ class Images(horizon.Panel):
     policy_rules = ((("image", "context_is_admin"),
                      ("image", "get_images")),)
 
-    def allowed(self, context):
-        if context['request'].user.services_region == 'SystemController':
-            return False
-        else:
-            return super(Images, self).allowed(context)
-
-    def nav(self, context):
-        if context['request'].user.services_region == 'SystemController':
-            return False
-        else:
-            return True


### PR DESCRIPTION
In Horizon Distributed Cloud, the “Admin/Compute/Images“ panel is not
enabled in SystemController. This change enables this panel.

Story: 2003408
Task: 24549

Signed-off-by: Kristine Bujold <kristine.bujold@windriver.com>