### PR TITLE
call sm-api through mgmt interface

### DIFF
--- a/openstack_dashboard/api/iservice.py
+++ b/openstack_dashboard/api/iservice.py
@@ -21,21 +21,20 @@ import logging
 
 from django.conf import settings
 import sm_client as smc
+from openstack_dashboard.api import base
 
 # Swap out with SM API
 LOG = logging.getLogger(__name__)
+SM_API_SERVICENAME = "smapi"
 
 
 def sm_client(request):
     # o = urlparse.urlparse(url_for(request, 'inventory'))
     # url = "://".join((o.scheme, o.netloc))
     insecure = getattr(settings, 'OPENSTACK_SSL_NO_VERIFY', False)
-    # LOG.debug('sysinv client conn using token "%s" and url "%s"'
-    # % (request.user.token.id, url))
-    # return smc.Client('1', url, token=request.user.token.id,
-    #                            insecure=insecure)
 
-    return smc.Client('1', 'http://localhost:7777',
+    sm_api_path = base.url_for(request, SM_API_SERVICENAME)
+    return smc.Client('1', sm_api_path,
                       token=request.user.token.id,
                       insecure=insecure)
 


### PR DESCRIPTION
As part of creating independent sm-api, sm-api binds to mgmt and oam
floating interface.
With this change, horizon retrieves sm-api service endpoint and
accesses sm-api via the endpoint.

This change was initially pushed to stx-gui. It should be in stx-horizon.

Story: 2002827
Task: 22745
Bug: 1793348

Signed-off-by: David Sullivan <david.sullivan@windriver.com>