### PR TITLE
Remove unused new_token code

### DIFF
--- a/openstack_dashboard/api/heat.py
+++ b/openstack_dashboard/api/heat.py
@@ -24,10 +24,7 @@ from six.moves.urllib import request
 from horizon import exceptions
 from horizon.utils import functions as utils
 from horizon.utils.memoized import memoized
-
-from openstack_auth import utils as auth_utils
 from openstack_dashboard.api import base
-
 from openstack_dashboard.contrib.developer.profiler import api as profiler
 
 
@@ -39,40 +36,14 @@ def format_parameters(params):
     return parameters
 
 
-# A portion of this code comes from an unsubmitted code in review
-# bug: https://bugs.launchpad.net/horizon/+bug/1515707
-#
-# Part of: https://review.openstack.org/gitweb?p=openstack/horizon.git
-# commit=a96ab75914b5290f6f21f1b52dd2ea116c42ece3
-def get_new_user_token_from(request):
-    """Generate new token for the given request to use in the context"""
-    tenant_id = request.user.project_id
-
-    endpoint = auth_utils.fix_auth_url_version(request.user.endpoint)
-    session = auth_utils.get_session()
-    # Keystone can be configured to prevent exchanging a scoped token for
-    # another token. Always use the unscoped token for requesting a
-    # scoped token.
-    unscoped_token = request.user.unscoped_token
-    auth = auth_utils.get_token_auth_plugin(auth_url=endpoint,
-                                            token=unscoped_token,
-                                            project_id=tenant_id)
-    auth_ref = auth.get_access(session)
-    return auth_ref.auth_token
-
-
 @memoized
-def heatclient(request, password=None, newtoken=False):
+def heatclient(request, password=None):
     api_version = "1"
     insecure = getattr(settings, 'OPENSTACK_SSL_NO_VERIFY', False)
     cacert = getattr(settings, 'OPENSTACK_SSL_CACERT', None)
     endpoint = base.url_for(request, 'orchestration')
-    if newtoken:
-        token = get_new_user_token_from(request)
-    else:
-        token = request.user.token.id
     kwargs = {
-        'token': token,
+        'token': request.user.token.id,
         'insecure': insecure,
         'ca_file': cacert,
         'username': request.user.username,
@@ -181,7 +152,7 @@ def _get_file_contents(from_data, files):
 
 @profiler.trace
 def stack_delete(request, stack_id):
-    return heatclient(request, newtoken=True).stacks.delete(stack_id)
+    return heatclient(request).stacks.delete(stack_id)
 
 
 @profiler.trace
@@ -196,7 +167,7 @@ def template_get(request, stack_id):
 
 @profiler.trace
 def stack_create(request, password=None, **kwargs):
-    return heatclient(request, password, newtoken=True).stacks.create(**kwargs)
+    return heatclient(request, password).stacks.create(**kwargs)
 
 
 @profiler.trace

--- a/openstack_dashboard/settings.py
+++ b/openstack_dashboard/settings.py
@@ -212,13 +212,7 @@ SESSION_COOKIE_SECURE = False
 # SESSION_TIMEOUT is a method to supersede the token timeout with a shorter
 # horizon session timeout (in seconds).  So if your token expires in 60
 # minutes, a value of 1800 will log users out after 30 minutes
-SESSION_TIMEOUT = 3000
-
-# TOKEN_TIMEOUT_MARGIN ensures the use is logged out before the token 
-# expires. This parameter specifies the number of seconds before the 
-# token expiry to log users out. If the token expires in 60 minutes, a 
-# value of 600 will log users out after 50 minutes.
-TOKEN_TIMEOUT_MARGIN = 600
+SESSION_TIMEOUT = 3300
 
 # When using cookie-based sessions, log error when the session cookie exceeds
 # the following size (common browsers drop cookies above a certain size):

--- a/openstack_dashboard/settings.py
+++ b/openstack_dashboard/settings.py
@@ -212,7 +212,13 @@ SESSION_COOKIE_SECURE = False
 # SESSION_TIMEOUT is a method to supersede the token timeout with a shorter
 # horizon session timeout (in seconds).  So if your token expires in 60
 # minutes, a value of 1800 will log users out after 30 minutes
-SESSION_TIMEOUT = 3300
+SESSION_TIMEOUT = 3000
+
+# TOKEN_TIMEOUT_MARGIN ensures the use is logged out before the token 
+# expires. This parameter specifies the number of seconds before the 
+# token expiry to log users out. If the token expires in 60 minutes, a 
+# value of 600 will log users out after 50 minutes.
+TOKEN_TIMEOUT_MARGIN = 600
 
 # When using cookie-based sessions, log error when the session cookie exceeds
 # the following size (common browsers drop cookies above a certain size):

--- a/openstack_dashboard/test/api_tests/heat_tests.py
+++ b/openstack_dashboard/test/api_tests/heat_tests.py
@@ -9,16 +9,12 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
-import unittest
-
 import six
 
 from django.conf import settings
 from django.test.utils import override_settings
 
 from horizon import exceptions
-
 from openstack_dashboard import api
 from openstack_dashboard.test import helpers as test
 
@@ -182,7 +178,6 @@ class HeatApiTests(test.APITestCase):
         template = api.heat.template_get(self.request, stack_id)
         self.assertEqual(mock_data_template.data, template.data)
 
-    @unittest.skip("WRS skip due to heatclient changes")
     def test_stack_create(self):
         api_stacks = self.stacks.list()
         stack = api_stacks[0]


### PR DESCRIPTION
If a horizon user's token expires during long running operations, those 
operations can fail. This occured during long running heat operations
(eg multiple stack deletions).  Previously we attempted to address this by 
extending the token. The token can not be extended and this code does not 
work as intended. This commit will remove the unused newtoken code.

The issue will be addressed by setting the TOKEN_TIMEOUT_MARGIN parameter
in horizon's local_settings.py

Partial-Bug: 1797186
Signed-off-by: David Sullivan <david.sullivan@windriver.com>