### PR TITLE
Fix to allow the csrf cookie to be renamed

### DIFF
--- a/openstack_dashboard/static/app/app.module.js
+++ b/openstack_dashboard/static/app/app.module.js
@@ -112,7 +112,7 @@
     $route
   ) {
 
-    $http.defaults.headers.post['X-CSRFToken'] = $cookies.csrftoken;
+    $http.defaults.headers.post['X-CSRFToken'] = $('input[name=csrfmiddlewaretoken]').val();
 
     // expose the legacy utils module
     horizon.utils = hzUtils;


### PR DESCRIPTION
This changes the csrf token used by the angularJS app to be
read from the html instead of from the csrftoken cookie.
It was assuming the default cookie name 'csrftoken' was
being used and when that is changed via the CSRF_COOKIE_NAME
django setting angular forms break.

The use case for changing this cookie name is when deploying
multiple django sites on the same domain (since cookies are shared)
and only one site can be used at once without different cookie
names.  This is the case for our dual horizon deployment with k8s.

The intent is to upstream this change along with the other CSRF
fixes already present in staging.

Story: 2004520
Task: 28259
Signed-off-by: Tyler Smith <tyler.smith@windriver.com>