### PR TITLE
fix issue: unable to hard-reboot VM instance on horizon

### DIFF
--- a/openstack_dashboard/api/nova.py
+++ b/openstack_dashboard/api/nova.py
@@ -642,7 +642,7 @@ def server_reboot(request, instance_id, soft_reboot=False):
     hardness = nova_servers.REBOOT_HARD
     if soft_reboot:
         hardness = nova_servers.REBOOT_SOFT
-        novaclient(request).servers.reboot(instance_id, hardness)
+    novaclient(request).servers.reboot(instance_id, hardness)
 
 
 @profiler.trace


### PR DESCRIPTION
Closes-Bug: #1808228

Signed-off-by: yhu6 <yong.hu@intel.com>

This issue was caused by an incorrect indent. 
In upstream there is no such a problem:
https://github.com/openstack/horizon/blob/master/openstack_dashboard/api/nova.py 